### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This library is perfect for small to medium complexity projects, since it allows
 Just give it a try and provide your feedback to grow it even better!
 
 ## Installation
-SwiftyIO is fully implemented in **Swift**, and is distributed as a Cocoa Touch Framework Library project. You can install from Cocoapods:
+SwiftyIO is fully implemented in **Swift**, and is distributed as a Cocoa Touch Framework Library project. You can install from CocoaPods:
 
 ```
 platform :ios, '8.0'


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
